### PR TITLE
Set parameter in constructor as selected network interface from DNS Settings 

### DIFF
--- a/NonHTTPProxy/src/josh/dnsspoof/UDPListener.java
+++ b/NonHTTPProxy/src/josh/dnsspoof/UDPListener.java
@@ -152,8 +152,8 @@ public class UDPListener implements Runnable{
 		try 
         {
 			Callbacks.printOutput("Using port: " + this.port);
-            datagramSocket = new DatagramSocket(this.port);
-           
+			InetAddress localAddress = InetAddress.getByName(this.ADDRESS[0] + "." + this.ADDRESS[1] + "." +this.ADDRESS[2] + "." +this.ADDRESS[3]);
+			datagramSocket = new DatagramSocket(this.port, localAddress);
             
         } catch (SocketException e) { 
         	Callbacks.printError(e.getMessage());


### PR DESCRIPTION
Using a constructor without explicitly specifying the interface often leads to an exception being thrown, and as a result, the datagramSocket is equal null. After that, the interface with the start button stops working.
